### PR TITLE
etc/50_ipv4_network_setup: use resolvconf

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libicd-network-ipv4 (0.27.0) unstable; urgency=medium
+
+  * Support resolvconf
+
+ -- Merlijn Wajer <merlijn@wizzup.org>  Fri, 29 Oct 2021 10:22:46 +0200
+
 libicd-network-ipv4 (0.26.0) unstable; urgency=medium
 
   * Add dnsmasq dependency.

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Section: net
 Package: libicd-network-ipv4
 Section: net
 Architecture: any
-Depends: icd2, udhcpc, dnsmasq, ${shlibs:Depends}
+Depends: icd2, udhcpc, dnsmasq, resolvconf, ${shlibs:Depends}
 Description: ICd2 ipv4 network configuration module
  ICd2 ipv4 network configuration module

--- a/etc/00_leste_dns
+++ b/etc/00_leste_dns
@@ -1,7 +1,2 @@
 domain-needed
 bogus-priv
-resolv-file=/var/run/resolv.conf
-resolv-file=/var/run/resolv.conf.wlan0
-resolv-file=/var/run/resolv.conf.ppp0
-resolv-file=/var/run/resolv.conf.lo
-resolv-file=/var/run/resolv.conf.gprs

--- a/etc/50_ipv4_network_setup
+++ b/etc/50_ipv4_network_setup
@@ -1,7 +1,6 @@
 #!/bin/sh
 # udhcpc script to use with ICD
 
-RESOLV_CONF="/var/run/resolv.conf.$interface"
 LEASE_PARAMS=/var/run/dhcp-params.conf
 
 case "$1" in
@@ -62,26 +61,22 @@ static | bound | renew)
 	    fi
 	fi
 
-	for ns in $dns
+	R=""
+	if [ -n "$domain" ]
+	then
+		R="${R}domain $domain
+"
+	fi
+	for i in $dns
 	do
-	  if egrep "^nameserver[\t ]*${ns}" $RESOLV_CONF > /dev/null
-	  then
-	      continue
-	  else
-	      echo -n > $RESOLV_CONF.tmp
-	      [ -n "$domain" ] && echo domain $domain >> $RESOLV_CONF.tmp
-	      for i in $dns
-	      do
-		echo nameserver $i >> $RESOLV_CONF.tmp
-	      done
-
-	      mv $RESOLV_CONF.tmp $RESOLV_CONF
-
-	      # Clear dnsmasq cache after getting new nameservers
-	      kill -SIGHUP `pidof dnsmasq`
-	      break
-	  fi
+		R="${R}nameserver $i
+"
 	done
+
+	echo -n "$R" | /sbin/resolvconf -a "${interface}.udhcpc"
+
+	# Clear dnsmasq cache after getting new nameservers
+	kill -SIGHUP `pidof dnsmasq`
 
 	/usr/bin/dbus-send \
 	    --system \
@@ -96,6 +91,7 @@ static | bound | renew)
 	;;
 deconfig)
 	/sbin/ifconfig $interface 0.0.0.0
+	/sbin/resolvconf -d "$interface.udhcpc" || true
 	rm -f $LEASE_PARAMS > /dev/null
 	/usr/bin/dbus-send \
 	    --system \


### PR DESCRIPTION
Resolves https://github.com/maemo-leste/bugtracker/issues/583

I initially looked at migrating to dhclient, since it already had a resolvconf hook in place, but dhclient works significantly different from udhcpc - in particular it cannot renew leases unless you terminate the process and start another one, which would require significantly rewriting the C source code of `libicd-network-ipv4`.

Also, udhcpc is probably more readily available than dhclient, so I decided to just add resolvconf support to the scripts instead.