### PR TITLE
prevent setting 0.0.0.0 as dns

### DIFF
--- a/etc/50_ipv4_network_setup
+++ b/etc/50_ipv4_network_setup
@@ -71,8 +71,11 @@ static | bound | renew)
 	D=""
 	for i in $dns
 	do
-		D="${D}nameserver $i
+		if [ -n "$i" && "$i" != "0.0.0.0" ]
+		then
+			D="${D}nameserver $i
 "
+		fi
 	done
 
 	# Let's just pick a default if none were provided... Quad9 seems better


### PR DESCRIPTION
not sure why udhcpc seems to output 0.0.0.0 , but its not helping anyone